### PR TITLE
Lifecycle hooks onMounted and onUnmounted should be used serveral times

### DIFF
--- a/lib/diff.js
+++ b/lib/diff.js
@@ -227,13 +227,23 @@ function updateTextNode(val, el) {
         el.textContent = val ? val.toString() : String(val);
     }
 }
-let mountHook = null;
-export function onMounted(fn) {
-    mountHook = fn;
+let mountHook = [];
+export function onMounted(fn = null) {
+    if(fn === null) return 
+    if(typeof fn !== 'function'){
+        console.error(`[Strve warn]: The parameter of onMounted is not a function!`)
+        return
+    }
+    mountHook.push(fn);
 }
-let unMountedHook = null;
-export function onUnmounted(fn) {
-    unMountedHook = fn;
+let unMountedHook = [];
+export function onUnmounted(fn = null) {
+    if(fn === null) return 
+    if(typeof fn !== 'function'){
+        console.error(`[Strve warn]: The parameter of onUnmounted is not a function!`)
+        return
+    }
+    unMountedHook.push(fn);
 }
 const p = getType(Promise) !== "undefined" && Promise.resolve();
 export const nextTick = (fn) => p.then(fn);
@@ -243,8 +253,12 @@ export function mountNode(dom, selector, status, name) {
         mount(_template, selector);
         state.oldTree = _template;
         state.isMounted = true;
-        mountHook && mountHook();
-        mountHook = null;
+        if (mountHook.length > 0) {
+            for (let i = 0, j = mountHook.length; i < j; i++) {
+                mountHook[i] && mountHook[i]();
+            }
+        }
+        mountHook = [];
     }
     else {
         const newTree = useFragmentNode(dom);
@@ -263,8 +277,12 @@ export function setData(callback, options) {
         })
             .then(() => {
             if (options && options.status === "useRouter") {
-                unMountedHook && unMountedHook();
-                unMountedHook = null;
+                if (unMountedHook.length > 0) {
+                    for (let i = 0, j = unMountedHook.length; i < j; i++) {
+                        unMountedHook[i] && unMountedHook[i]();
+                    }
+                }
+                unMountedHook = [];
                 state.isMounted = false;
                 state._el.innerHTML = "";
                 const tem = state._template();

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -293,14 +293,24 @@ function updateTextNode(val: any, el: HTMLElement): void {
   }
 }
 
-let mountHook: Function | null = null;
-export function onMounted(fn: Function): void {
-  mountHook = fn;
+let mountHook: Function[] = [];
+export function onMounted(fn: Function |  null = null): void {
+  if(fn === null) return 
+    if(typeof fn !== 'function'){
+        console.error(`[Strve warn]: The parameter of onMounted is not a function!`)
+        return
+    }
+  mountHook.push(fn);
 }
 
-let unMountedHook: Function | null = null;
-export function onUnmounted(fn: Function): void {
-  unMountedHook = fn;
+let unMountedHook: Function[] = [];
+export function onUnmounted(fn: Function |  null = null): void {
+  if(fn === null) return 
+  if(typeof fn !== 'function'){
+      console.error(`[Strve warn]: The parameter of onUnmounted is not a function!`)
+      return
+  }
+  unMountedHook.push(fn);
 }
 
 const p = getType(Promise) !== "undefined" && Promise.resolve();
@@ -317,8 +327,12 @@ export function mountNode(
     mount(_template, selector);
     state.oldTree = _template;
     state.isMounted = true;
-    mountHook && mountHook();
-    mountHook = null;
+    if (mountHook.length > 0) {
+      for (let i = 0, j = mountHook.length; i < j; i++) {
+          mountHook[i] && mountHook[i]();
+      }
+    }
+    mountHook = [];
   } else {
     const newTree: vnodeType = useFragmentNode(dom);
     patch(state.oldTree, newTree, status);
@@ -341,8 +355,12 @@ export function setData(
       })
       .then(() => {
         if (options && options.status === "useRouter") {
-          unMountedHook && unMountedHook();
-          unMountedHook = null;
+          if (unMountedHook.length > 0) {
+            for (let i = 0, j = unMountedHook.length; i < j; i++) {
+                  unMountedHook[i] && unMountedHook[i]();
+              }
+          }
+          unMountedHook = [];
           state.isMounted = false;
           state._el.innerHTML = "";
           const tem = state._template();

--- a/types/diff.d.ts
+++ b/types/diff.d.ts
@@ -26,8 +26,8 @@ interface setDataOptionsType {
 export declare const domInfo: any;
 export declare let propsData: any;
 export declare function mount(vnode: vnodeType, container: HTMLElement | Node, anchor?: Node): void;
-export declare function onMounted(fn: Function): void;
-export declare function onUnmounted(fn: Function): void;
+export declare function onMounted(fn: Function | null): void;
+export declare function onUnmounted(fn: Function | null): void;
 export declare const nextTick: (fn: () => void) => Promise<void>;
 export declare function mountNode(dom: vnodeType, selector?: Node, status?: string, name?: string): void;
 export declare function setData(callback: Function, options: setDataOptionsType): Promise<void>;


### PR DESCRIPTION
Lifecycle hooks `onMounted` and `onUnmounted` should be applied multiple times, such as used in different components. But they can only be used once, because the variables `mountHook` and `unMountedHook` are just ordinary values.

So I modified three files about lifecycle hooks including `lib/diff.js`, `src/diff.ts` and `types/diff.d.ts`, to allow them to be used multiple times. 

The programme you created is exciting, so I read and explored your code and history of commit until nearly 3.00. I believe I could understand your most idea by your code. If you allow, I would like to be your partner. The programme is being developed. It has more potential to be optimize. It is my hope that we can build a powerful and popular framework for all web developers.

