### PR TITLE
Update Mount Function for Single Mounting

### DIFF
--- a/src/init.ts
+++ b/src/init.ts
@@ -62,6 +62,27 @@ export function createApp(template: Function): {
 } {
   const app = {
     mount(el: HTMLElement | String) {
+      if (state.isMounted) {
+        console.warn(
+          `[Strve warn]: app is already mounted, cannot mount again.`
+        );
+        return;
+      }
+
+      state._el = normalizeContainer(el);
+      state._template = template;
+      state.isMounted = true;
+
+      if (!state._el) {
+        console.warn(
+          `[Strve warn]: Failed to mount app: mount target selector "${el}" returned null.`
+        );
+        return;
+      }
+
+      state._el.innerHTML = "";
+      const root = mountNode(state._template(), state._el);
+      state.oldTree = root;
       if (normalizeContainer(el)) {
         const tem = template();
         if (getType(tem) === "array") {


### PR DESCRIPTION
Refactored the mount function to ensure that the app can only be mounted once. Added a check to prevent re-mounting if the app is already mounted.

1. The mount function within the createApp function has been updated to prevent re-mounting. If the app is already mounted, a warning will be displayed, and no further mounting will occur.
2. A check has been added to ensure that the code only mounts once and a warning is displayed if the mount target selector returns null.